### PR TITLE
Fixing Issue with _id not having sub-second resolution / jobs not sorted by insertion order

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,9 @@
+**NOTES about this Fork:**
+
+Please do not use this fork directly, as it is work in progress
+
+
+
 Mongo-Resque
 ============
 


### PR DESCRIPTION
fixing three things in lib/resque.rb

1) pop() sorts now by :resque_enqueue_timestamp, instead of _id
2) list_range() and therefore peek() sort by :resque_enqueue_timestamp

3) push sets the resque_enqueue_timestamp only if it was not handed-in via item,
    allowing the user to override the :resque_enqueue_timestamp, so a job can be queued with it's origin timestamp
    and/or can be put back into the queue with the original timestamp if it failed

  item[:resque_enqueue_timestamp] ||= Time.now   # instead of =

TODO: the code should create/ensure an index for each queue:
      {resque_enqueue_timestamp: 1} , {background: true}
